### PR TITLE
Find children should order

### DIFF
--- a/src/Storage/DbalNestedSet.php
+++ b/src/Storage/DbalNestedSet.php
@@ -137,7 +137,7 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
       ->andWhere('parent.revision_id = :revision_id')
       ->andwhere('child.left_pos > parent.left_pos')
       ->andWhere('child.right_pos < parent.right_pos')
-      ->orderBy('left_pos', 'ASC')
+      ->orderBy('child.left_pos', 'ASC')
       ->setParameter(':id', $node->getId())
       ->setParameter(':revision_id', $node->getRevisionId());
     if ($depth > 0) {

--- a/src/Storage/DbalNestedSet.php
+++ b/src/Storage/DbalNestedSet.php
@@ -137,6 +137,7 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
       ->andWhere('parent.revision_id = :revision_id')
       ->andwhere('child.left_pos > parent.left_pos')
       ->andWhere('child.right_pos < parent.right_pos')
+      ->orderBy('left_pos', 'ASC')
       ->setParameter(':id', $node->getId())
       ->setParameter(':revision_id', $node->getRevisionId());
     if ($depth > 0) {

--- a/tests/Functional/DbalNestedSetTest.php
+++ b/tests/Functional/DbalNestedSetTest.php
@@ -484,14 +484,6 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
       ]);
     $this->connection->insert($this->tableName,
       [
-        'id' => 7,
-        'revision_id' => 1,
-        'left_pos' => 11,
-        'right_pos' => 16,
-        'depth' => 2,
-      ]);
-    $this->connection->insert($this->tableName,
-      [
         'id' => 8,
         'revision_id' => 1,
         'left_pos' => 17,
@@ -504,6 +496,14 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
         'revision_id' => 1,
         'left_pos' => 19,
         'right_pos' => 20,
+        'depth' => 2,
+      ]);
+    $this->connection->insert($this->tableName,
+      [
+        'id' => 7,
+        'revision_id' => 1,
+        'left_pos' => 11,
+        'right_pos' => 16,
         'depth' => 2,
       ]);
     $this->connection->insert($this->tableName,


### PR DESCRIPTION
The old test passed because they were inserted in ascending order.
My local Drupal test is inserting in random order.
Made library test do the same.