### PR TITLE
Handle stale references

### DIFF
--- a/tests/Functional/DbalNestedSetTest.php
+++ b/tests/Functional/DbalNestedSetTest.php
@@ -525,13 +525,7 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
     $oldParent = $this->nestedSet->getNode(new NodeKey(7, 1));
     $newParent = $this->nestedSet->getNode(new NodeKey(8, 1));
 
-    echo PHP_EOL . "Before:";
-    $this->printTree($this->nestedSet->getTree());
-
     $this->nestedSet->adoptChildren($oldParent, $newParent);
-
-    echo PHP_EOL . "After:";
-    $this->printTree($this->nestedSet->getTree());
 
     // Check new parent has all children.
     $node = $this->nestedSet->getNode(new NodeKey(8, 1));


### PR DESCRIPTION
In a high-volume environment, it is possible that a node has stale values in its left/right/depth if another process has updated the tree between the time the node was fetched and the time one of the move/insert methods is called.