### PR TITLE
Only use node key in API

### DIFF
--- a/src/NestedSetInterface.php
+++ b/src/NestedSetInterface.php
@@ -10,20 +10,20 @@ interface NestedSetInterface {
   /**
    * Inserts a node below the target node.
    *
-   * @param \PNX\NestedSet\Node $target
+   * @param \PNX\NestedSet\NodeKey $parent
    *   The target node to insert below.
-   * @param \PNX\NestedSet\NodeKey $nodeKey
+   * @param \PNX\NestedSet\NodeKey $child
    *   The node to insert.
    *
    * @return \PNX\NestedSet\Node
    *   Returns a new node with position values set.
    */
-  public function addNodeBelow(Node $target, NodeKey $nodeKey);
+  public function addNodeBelow(NodeKey $parent, NodeKey $child);
 
   /**
    * Inserts a node before the target node.
    *
-   * @param \PNX\NestedSet\Node $target
+   * @param \PNX\NestedSet\NodeKey $targetKey
    *   The target node to insert before.
    * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node key to insert.
@@ -31,12 +31,12 @@ interface NestedSetInterface {
    * @return \PNX\NestedSet\Node
    *   Returns a node with position values set.
    */
-  public function addNodeBefore(Node $target, NodeKey $nodeKey);
+  public function addNodeBefore(NodeKey $targetKey, NodeKey $nodeKey);
 
   /**
    * Inserts a node after the target node.
    *
-   * @param \PNX\NestedSet\Node $target
+   * @param \PNX\NestedSet\NodeKey $targetKey
    *   The target node to insert after.
    * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node key to insert.
@@ -44,7 +44,7 @@ interface NestedSetInterface {
    * @return \PNX\NestedSet\Node
    *   Returns a node with position values set.
    */
-  public function addNodeAfter(Node $target, NodeKey $nodeKey);
+  public function addNodeAfter(NodeKey $targetKey, NodeKey $nodeKey);
 
   /**
    * Inserts a root node.
@@ -60,18 +60,18 @@ interface NestedSetInterface {
   /**
    * Deletes a node and moves descendants up a level.
    *
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to delete.
    */
-  public function deleteNode(Node $node);
+  public function deleteNode(NodeKey $nodeKey);
 
   /**
    * Deletes a node and all it's descendants.
    *
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to delete.
    */
-  public function deleteSubTree(Node $node);
+  public function deleteSubTree(NodeKey $nodeKey);
 
   /**
    * Finds all descendants of a node.
@@ -122,7 +122,7 @@ interface NestedSetInterface {
   /**
    * Gets a node for the ID and Revision ID.
    *
-   * @param NodeKey $nodeKey
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node key.
    *
    * @return \PNX\NestedSet\Node
@@ -133,50 +133,50 @@ interface NestedSetInterface {
   /**
    * Moves a subtree to be a new root of the tree.
    *
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to become the new root node.
    */
-  public function moveSubTreeToRoot(Node $node);
+  public function moveSubTreeToRoot(NodeKey $nodeKey);
 
   /**
    * Moves a node and its sub-tree below the target node.
    *
-   * @param Node $target
+   * @param \PNX\NestedSet\NodeKey $targetKey
    *   The node to move below.
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to move.
    */
-  public function moveSubTreeBelow(Node $target, Node $node);
+  public function moveSubTreeBelow(NodeKey $targetKey, NodeKey $nodeKey);
 
   /**
    * Moves a node and its sub-tree before the target node.
    *
-   * @param Node $target
+   * @param \PNX\NestedSet\NodeKey $targetKey
    *   The node to move before.
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to move.
    */
-  public function moveSubTreeBefore(Node $target, Node $node);
+  public function moveSubTreeBefore(NodeKey $targetKey, NodeKey $nodeKey);
 
   /**
    * Moves a node and its sub-tree after the target node.
    *
-   * @param Node $target
+   * @param \PNX\NestedSet\NodeKey $targetKey
    *   The node to move after.
-   * @param \PNX\NestedSet\Node $node
+   * @param \PNX\NestedSet\NodeKey $nodeKey
    *   The node to move.
    */
-  public function moveSubTreeAfter(Node $target, Node $node);
+  public function moveSubTreeAfter(NodeKey $targetKey, NodeKey $nodeKey);
 
   /**
    * Swaps the parent of a sub-tree to a new parent.
    *
-   * @param \PNX\NestedSet\Node $oldParent
+   * @param \PNX\NestedSet\NodeKey $oldParentKey
    *   The old parent.
-   * @param \PNX\NestedSet\Node $newParent
+   * @param \PNX\NestedSet\NodeKey $newParentKey
    *   The new parent.
    */
-  public function adoptChildren(Node $oldParent, Node $newParent);
+  public function adoptChildren(NodeKey $oldParentKey, NodeKey $newParentKey);
 
   /**
    * Gets a node at a specified left position.

--- a/src/Storage/DbalNestedSet.php
+++ b/src/Storage/DbalNestedSet.php
@@ -23,18 +23,18 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function addNodeBelow(Node $target, NodeKey $nodeKey) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function addNodeBelow(NodeKey $parentKey, NodeKey $child) {
+    $target = $this->getNode($parentKey);
     $newLeftPosition = $target->getRight();
     $depth = $target->getDepth() + 1;
-    return $this->insertNodeAtPostion($newLeftPosition, $depth, $nodeKey);
+    return $this->insertNodeAtPostion($newLeftPosition, $depth, $child);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addNodeBefore(Node $target, NodeKey $nodeKey) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function addNodeBefore(NodeKey $targetKey, NodeKey $nodeKey) {
+    $target = $this->getNode($targetKey);
     $newLeftPosition = $target->getLeft();
     $depth = $target->getDepth();
     return $this->insertNodeAtPostion($newLeftPosition, $depth, $nodeKey);
@@ -43,8 +43,8 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function addNodeAfter(Node $target, NodeKey $nodeKey) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function addNodeAfter(NodeKey $targetKeyKey, NodeKey $nodeKey) {
+    $target = $this->getNode($targetKeyKey);
     $newLeftPosition = $target->getRight() + 1;
     $depth = $target->getDepth();
     return $this->insertNodeAtPostion($newLeftPosition, $depth, $nodeKey);
@@ -225,8 +225,8 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteNode(Node $node) {
-    $node = $this->ensureNodeIsFresh($node);
+  public function deleteNode(NodeKey $nodeKey) {
+    $node = $this->getNode($nodeKey);
     if ($node->getLeft() < 1 || $node->getRight() < 1) {
       throw new \InvalidArgumentException("Left and right values must be > 0");
     }
@@ -271,8 +271,8 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteSubTree(Node $node) {
-    $node = $this->ensureNodeIsFresh($node);
+  public function deleteSubTree(NodeKey $nodeKey) {
+    $node = $this->getNode($nodeKey);
     $left = $node->getLeft();
     $right = $node->getRight();
     $width = $right - $left + 1;
@@ -308,16 +308,17 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function moveSubTreeToRoot(Node $node) {
-    $root = $this->findRoot($node->getNodeKey());
-    $this->moveSubTreeBefore($root, $node);
+  public function moveSubTreeToRoot(NodeKey $nodeKey) {
+    $root = $this->findRoot($nodeKey);
+    $this->moveSubTreeBefore($root->getNodeKey(), $nodeKey);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function moveSubTreeBelow(Node $target, Node $node) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function moveSubTreeBelow(NodeKey $targetKey, NodeKey $nodeKey) {
+    $target = $this->getNode($targetKey);
+    $node = $this->getNode($nodeKey);
     $newLeftPosition = $target->getLeft() + 1;
     $this->moveSubTreeToPosition($newLeftPosition, $node, $target->getDepth() + 1);
   }
@@ -325,8 +326,9 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function moveSubTreeBefore(Node $target, Node $node) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function moveSubTreeBefore(NodeKey $targetKey, NodeKey $nodeKey) {
+    $target = $this->getNode($targetKey);
+    $node = $this->getNode($nodeKey);
     $newLeftPosition = $target->getLeft();
     $this->moveSubTreeToPosition($newLeftPosition, $node, $target->getDepth());
   }
@@ -334,8 +336,9 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function moveSubTreeAfter(Node $target, Node $node) {
-    $target = $this->ensureNodeIsFresh($target);
+  public function moveSubTreeAfter(NodeKey $targetKey, NodeKey $nodeKey) {
+    $target = $this->getNode($targetKey);
+    $node = $this->getNode($nodeKey);
     $newLeftPosition = $target->getRight() + 1;
     $this->moveSubTreeToPosition($newLeftPosition, $node, $target->getDepth());
   }
@@ -343,9 +346,9 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
   /**
    * {@inheritdoc}
    */
-  public function adoptChildren(Node $oldParent, Node $newParent) {
-    $children = $this->findChildren($oldParent->getNodeKey());
-    $newParent = $this->ensureNodeIsFresh($newParent);
+  public function adoptChildren(NodeKey $oldParentKey, NodeKey $newParentKey) {
+    $children = $this->findChildren($oldParentKey);
+    $newParent = $this->getNode($newParentKey);
     $newLeftPosition = $newParent->getRight();
     $this->moveMultipleSubTreesToPosition($newLeftPosition, $children, $newParent->getDepth() + 1);
   }

--- a/tests/Functional/DbalNestedSetTest.php
+++ b/tests/Functional/DbalNestedSetTest.php
@@ -180,10 +180,9 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
   public function testInsertNodeBelowWithExistingChildren() {
 
     $parentNodeKey = new NodeKey(3, 1);
-    $parent = $this->nestedSet->getNode($parentNodeKey);
     $childNodeKey = new NodeKey(12, 1);
 
-    $newNode = $this->nestedSet->addNodeBelow($parent, $childNodeKey);
+    $newNode = $this->nestedSet->addNodeBelow($parentNodeKey, $childNodeKey);
 
     // Should be inserted in right-most spot.
     $this->assertEquals(21, $newNode->getLeft());
@@ -199,10 +198,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    * Tests inserting a node below a parent with no children.
    */
   public function testInsertNodeBelowWithNoChildren() {
-    $target = $this->nestedSet->getNode(new NodeKey(6, 1));
+    $targetKey = new NodeKey(6, 1);
     $nodeKey = new NodeKey(13, 1);
 
-    $newNode = $this->nestedSet->addNodeBelow($target, $nodeKey);
+    $newNode = $this->nestedSet->addNodeBelow($targetKey, $nodeKey);
 
     // Should be inserted below 6 with depth 4.
     $this->assertEquals(7, $newNode->getLeft());
@@ -219,10 +218,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    * Tests inserting a node before another sibling.
    */
   public function testInsertNodeBefore() {
-    $parent = $this->nestedSet->getNode(new NodeKey(6, 1));
+    $parentKey = new NodeKey(6, 1);
     $childNodeKey = new NodeKey(14, 1);
 
-    $newNode = $this->nestedSet->addNodeBefore($parent, $childNodeKey);
+    $newNode = $this->nestedSet->addNodeBefore($parentKey, $childNodeKey);
 
     // Should be inserted below 6 with depth 4.
     $this->assertEquals(6, $newNode->getLeft());
@@ -239,10 +238,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    * Tests inserting a node after another sibling.
    */
   public function testInsertNodeAfter() {
-    $parent = $this->nestedSet->getNode(new NodeKey(5, 1));
+    $parentKey = new NodeKey(5, 1);
     $childNodeKey = new NodeKey(15, 1);
 
-    $newNode = $this->nestedSet->addNodeAfter($parent, $childNodeKey);
+    $newNode = $this->nestedSet->addNodeAfter($parentKey, $childNodeKey);
 
     // Should be inserted below 6 with depth 4.
     $this->assertEquals(6, $newNode->getLeft());
@@ -260,9 +259,8 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testDeleteNode() {
     $nodeKey = new NodeKey(4, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
-    $this->nestedSet->deleteNode($node);
+    $this->nestedSet->deleteNode($nodeKey);
 
     // Node should be deleted.
     $node = $this->nestedSet->getNode($nodeKey);
@@ -285,7 +283,7 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testDeleteNodeInvalid() {
     $this->setExpectedException(\InvalidArgumentException::class);
-    $node = new Node(new NodeKey(1, 1), -1, -1, 0);
+    new Node(new NodeKey(1, 1), -1, -1, 0);
   }
 
   /**
@@ -294,9 +292,8 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
   public function testDeleteSubTree() {
 
     $nodeKey = new NodeKey(4, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
-    $this->nestedSet->deleteSubTree($node);
+    $this->nestedSet->deleteSubTree($nodeKey);
 
     // Node should be deleted.
     $node = $this->nestedSet->getNode($nodeKey);
@@ -315,15 +312,14 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testMoveSubTreeBelow() {
 
-    $parent = $this->nestedSet->getNode(new NodeKey(1, 1));
+    $parentKey = new NodeKey(1, 1);
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
-    $this->nestedSet->moveSubTreeBelow($parent, $node);
+    $this->nestedSet->moveSubTreeBelow($parentKey, $nodeKey);
     $this->assertNodeMovedBelow();
 
-    $node = $this->nestedSet->getNode(new NodeKey(7, 1));
-    $this->nestedSet->moveSubTreeBelow($parent, $node);
+    $nodeKey = new NodeKey(7, 1);
+    $this->nestedSet->moveSubTreeBelow($parentKey, $nodeKey);
     $this->assertNodeMovedBelow();
 
   }
@@ -333,12 +329,11 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testMoveSubTreeBelowEndParentNode() {
 
-    $parent = $this->nestedSet->getNode(new NodeKey(1, 1));
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
+    $rootKey = new NodeKey(12, 1);
 
-    $newRoot = $this->nestedSet->addRootNode(new NodeKey(12, 1));
-    $this->nestedSet->moveSubTreeBelow($newRoot, $node);
+    $this->nestedSet->addRootNode($rootKey);
+    $this->nestedSet->moveSubTreeBelow($rootKey, $nodeKey);
 
     // Check node is in new position.
     $node = $this->nestedSet->getNode($nodeKey);
@@ -370,13 +365,14 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testMoveSubTreeBelowEndChildNode() {
 
-    $parent = $this->nestedSet->getNode(new NodeKey(1, 1));
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
+    $rootKey = new NodeKey(12, 1);
 
-    $newRoot = $this->nestedSet->addRootNode(new NodeKey(12, 1));
-    $newChild = $this->nestedSet->addNodeBelow($newRoot, new NodeKey(13, 1));
-    $this->nestedSet->moveSubTreeBelow($newChild, $node);
+    $this->nestedSet->addRootNode($rootKey);
+
+    $childKey = new NodeKey(13, 1);
+    $newChild = $this->nestedSet->addNodeBelow($rootKey, $childKey);
+    $this->nestedSet->moveSubTreeBelow($childKey, $nodeKey);
 
     // Check node is in new position.
     $node = $this->nestedSet->getNode($nodeKey);
@@ -409,9 +405,8 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
   public function testMoveSubTreeToRoot() {
 
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
-    $this->nestedSet->moveSubTreeToRoot($node);
+    $this->nestedSet->moveSubTreeToRoot($nodeKey);
 
     // Assert we are at the root now.
     $newRoot = $this->nestedSet->getNode($nodeKey);
@@ -432,19 +427,12 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testMoveSubTreeBefore() {
 
-    $target = $this->nestedSet->getNode(new NodeKey(4, 1));
+    $targetKey = new NodeKey(4, 1);
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
-    $this->nestedSet->moveSubTreeBefore($target, $node);
+    $this->nestedSet->moveSubTreeBefore($targetKey, $nodeKey);
     $this->assertNodeMovedBefore();
 
-    $node = $this->nestedSet->getNode(new NodeKey(7, 1));
-    // Check node is in new position.
-    $node = $this->nestedSet->getNode($nodeKey);
-
-    $this->nestedSet->moveSubTreeBefore($target, $node);
-    $this->assertNodeMovedBefore();
   }
 
   /**
@@ -452,10 +440,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testAdoptChildren() {
 
-    $oldParent = $this->nestedSet->getNode(new NodeKey(7, 1));
-    $newParent = $this->nestedSet->getNode(new NodeKey(4, 1));
+    $oldParentKey = new NodeKey(7, 1);
+    $newParentKey = new NodeKey(4, 1);
 
-    $this->nestedSet->adoptChildren($oldParent, $newParent);
+    $this->nestedSet->adoptChildren($oldParentKey, $newParentKey);
 
     // Check new parent has all children.
     $node = $this->nestedSet->getNode(new NodeKey(4, 1));
@@ -487,10 +475,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testAdoptChildrenWithDecendents() {
 
-    $oldParent = $this->nestedSet->getNode(new NodeKey(3, 1));
-    $newParent = $this->nestedSet->getNode(new NodeKey(4, 1));
+    $oldParentKey = new NodeKey(3, 1);
+    $newParentKey = new NodeKey(4, 1);
 
-    $this->nestedSet->adoptChildren($oldParent, $newParent);
+    $this->nestedSet->adoptChildren($oldParentKey, $newParentKey);
 
     // Check new parent has all children.
     $node = $this->nestedSet->getNode(new NodeKey(4, 1));
@@ -522,10 +510,10 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testAdoptChildrenNoExisting() {
 
-    $oldParent = $this->nestedSet->getNode(new NodeKey(7, 1));
-    $newParent = $this->nestedSet->getNode(new NodeKey(8, 1));
+    $oldParentKey = new NodeKey(7, 1);
+    $newParentKey = new NodeKey(8, 1);
 
-    $this->nestedSet->adoptChildren($oldParent, $newParent);
+    $this->nestedSet->adoptChildren($oldParentKey, $newParentKey);
 
     // Check new parent has all children.
     $node = $this->nestedSet->getNode(new NodeKey(8, 1));
@@ -557,9 +545,9 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    */
   public function testAddRootNodeWhenEmpty() {
 
-    $rootNode = $this->nestedSet->getNode(new NodeKey(1, 1));
+    $rootNodeKey = new NodeKey(1, 1);
 
-    $this->nestedSet->deleteSubTree($rootNode);
+    $this->nestedSet->deleteSubTree($rootNodeKey);
 
     $nodeKey = new NodeKey(12, 1);
 
@@ -796,21 +784,19 @@ class DbalNestedSetTest extends \PHPUnit_Framework_TestCase {
    * Tests moving a sub-tree under a parent node.
    */
   public function testSimultaneousMoveSubTreeBelow() {
-    $parent = $this->nestedSet->getNode(new NodeKey(1, 1));
+    $parentKey = new NodeKey(1, 1);
     $nodeKey = new NodeKey(7, 1);
-    $node = $this->nestedSet->getNode($nodeKey);
 
     // We are planning to move node 7 below node 1, but at the same time,
     // let's move node 8 around a bit.
     $otherNodeKey = new NodeKey(8, 1);
-    $otherNode = $this->nestedSet->getNode($otherNodeKey);
 
     // Now we move node 8 around.
-    $this->nestedSet->moveSubTreeBelow($parent, $otherNode);
+    $this->nestedSet->moveSubTreeBelow($parentKey, $otherNodeKey);
 
     // And then we move node 7 around, but at this point our Node object has
     // values for left and right that are stale.
-    $this->nestedSet->moveSubTreeBelow($parent, $node);
+    $this->nestedSet->moveSubTreeBelow($parentKey, $nodeKey);
 
     // Check nodes are in the correct positions.
     $this->assertNodeMovedBelow(2);


### PR DESCRIPTION
To support concurrency, ensure only the node keys are used in transactions.

This is an API break.