### PR TITLE
Optimise the use case where the two conditions overlap in an =

### DIFF
--- a/src/Storage/DbalNestedSet.php
+++ b/src/Storage/DbalNestedSet.php
@@ -142,13 +142,19 @@ class DbalNestedSet extends BaseDbalStorage implements NestedSetInterface {
       ->orderBy('child.left_pos', 'ASC')
       ->setParameter('id', $nodeKey->getId())
       ->setParameter('revision_id', $nodeKey->getRevisionId());
-    if ($start > 0) {
-      $query->andWhere('child.depth >= :start_depth + parent.depth')
-        ->setParameter('start_depth', $start);
+    if ($depth > 0 && $depth == $start) {
+      $query->andWhere('child.depth = :depth + parent.depth')
+        ->setParameter('depth', $depth);
     }
-    if ($depth > 0) {
-      $query->andWhere('child.depth <= :depth + parent.depth')
-        ->setParameter('depth', $start + $depth - 1);
+    else {
+      if ($start > 0) {
+        $query->andWhere('child.depth >= :start_depth + parent.depth')
+          ->setParameter('start_depth', $start);
+      }
+      if ($depth > 0) {
+        $query->andWhere('child.depth <= :depth + parent.depth')
+          ->setParameter('depth', $start + $depth - 1);
+      }
     }
     $stmt = $query->executeQuery();
     assert($stmt instanceof Result);


### PR DESCRIPTION
There is a special use case where the depth and the start overlap and create SQL that looks like `(a <= x) & (a >= x)`... this is equivalent to `(a=x)` and as a result allows better use of the table indexes, specifically the `(id, revision_id, left_pos, right_pos, depth)`.

Before optimisation:

| id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|    1 | SIMPLE      | parent | const | PRIMARY,IDX_E1907B87BF3967501DFA7C8F5E183DDBDEADD74FAA31C69,IDX_E1907B875E183DDBDEADD74,IDX_E1907B87BDEADD74 | PRIMARY              | 8       | const,const | 1    |                                                    |
|    1 | SIMPLE      | child  | range | IDX_E1907B875E183DDBDEADD74,IDX_E1907B87BDEADD74,IDX_E1907B87FAA31C69                                        | IDX_E1907B87BDEADD74 | 20       | NULL        | 145780    | Using index condition; Using where; Using filesort |

After optimisation:

| id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
|    1 | SIMPLE      | parent | const      | PRIMARY,IDX_E1907B87BF3967501DFA7C8F5E183DDBDEADD74FAA31C69,IDX_E1907B875E183DDBDEADD74,IDX_E1907B87BDEADD74 | PRIMARY                                   | 8       | const,const | 1          |                                                                        |
|    1 | SIMPLE      | child  | ref,filter | IDX_E1907B875E183DDBDEADD74,IDX_E1907B87BDEADD74,IDX_E1907B87FAA31C69                                        | IDX_E1907B87FAA31C69,IDX_E1907B87BDEADD74 | 4,4     | const       | 12148 | Using index condition; Using where; Using filesort; Using rowid filter |
